### PR TITLE
Add UnwrapOrElse overload for computing the value from the error

### DIFF
--- a/ResultSharp.Tests/ResultTests.cs
+++ b/ResultSharp.Tests/ResultTests.cs
@@ -90,6 +90,16 @@ namespace ResultSharp.Tests
 		}
 
 		[Fact]
+		public void UnwrapOrElse_FaultedResult_ShouldReturnValueFromClosureBasedOnError()
+		{
+			Result<string, string> result = Err("err");
+
+			var actual = result.UnwrapOrElse(err => $"computed {err}");
+
+			actual.Should().Be("computed err");
+		}
+
+		[Fact]
 		public void UnwrapErr_OkResult_ShouldThrow()
 		{
 			Result<int, string> result = Ok(0);

--- a/ResultSharp/ResultT.cs
+++ b/ResultSharp/ResultT.cs
@@ -150,6 +150,11 @@ namespace ResultSharp
 
 		[Pure]
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public T UnwrapOrElse(Func<string, T> op) =>
+			Inner.UnwrapOrElse(op);
+
+		[Pure]
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public string UnwrapErr() =>
 			Inner.UnwrapErr();
 

--- a/ResultSharp/ResultTE.cs
+++ b/ResultSharp/ResultTE.cs
@@ -265,6 +265,16 @@ namespace ResultSharp
 			Match(val => val, _ => op());
 
 		/// <summary>
+		/// Returns the contained Ok value, or computes it from the error value using the provided delegate
+		/// </summary>
+		/// <param name="op">operation</param>
+		/// <returns>The contained or computed value</returns>
+		[Pure]
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public T UnwrapOrElse(Func<E, T> op) =>
+			Match(val => val, op);
+
+		/// <summary>
 		/// Returns the contained Err value, or throws UnwrapErrException if
 		/// the Result is Ok
 		/// </summary>

--- a/ResultSharp/ResultTE.cs
+++ b/ResultSharp/ResultTE.cs
@@ -255,7 +255,7 @@ namespace ResultSharp
 			Match(val => val, _ => defaultValue);
 
 		/// <summary>
-		/// Returns the contained Ok value, or computes if from the delegate provided
+		/// Returns the contained Ok value, or computes it from the provided delegate
 		/// </summary>
 		/// <param name="op">operation</param>
 		/// <returns>The contained or computed value</returns>


### PR DESCRIPTION
This PR introduces an overload to the `UnwrapOrElse` method, where the delegate is invoked with the error value to compute the return value.

Not sure if it's a good idea to overload based on a function type though, maybe it should have its own name?