### PR TITLE
Add Linq extension methods

### DIFF
--- a/ResultSharp.Tests/ResultLinqExtensionsTests.cs
+++ b/ResultSharp.Tests/ResultLinqExtensionsTests.cs
@@ -1,0 +1,58 @@
+﻿using FluentAssertions;
+using Xunit;
+
+namespace ResultSharp.Tests
+{
+	public class ResultLinqExtensionsTests
+	{
+		[Fact]
+		public void SelectMany_ResultTE_Ok()
+		{
+			var result =
+				from a in Result.Ok<string, string>("foo")
+				from b in Result.Ok<int, string>(123)
+				from c in Result.Ok<string, string>("bar")
+				select (a, b, c);
+
+			result.Unwrap().Should().Be(("foo", 123, "bar"));
+		}
+
+		[Fact]
+		public void SelectMany_ResultTE_Err()
+		{
+			var result =
+				from a in Result.Ok<string, string>("ok")
+				from b in Result.Err<string, string>("err1")
+				from c in Result.Ok<string, string>("ok")
+				from d in Result.Err<string, string>("err2")
+				select (a, b, c);
+
+			result.UnwrapErr().Should().Be("err1");
+		}
+
+		[Fact]
+		public void SelectMany_ResultT_Ok()
+		{
+			var result =
+				from a in Result.Ok("foo")
+				from b in Result.Ok(123)
+				from c in Result.Ok("bar")
+				select (a, b, c);
+
+			result.Unwrap().Should().Be(("foo", 123, "bar"));
+		}
+
+		[Fact]
+		public void SelectMany_ResultT_Err()
+		{
+			var result =
+				from a in Result.Ok("ok")
+				from b in Result.Err<string>("err1")
+				from c in Result.Ok("ok")
+				from d in Result.Err<string>("err2")
+				select (a, b, c);
+
+			result.UnwrapErr().Should().Be("err1");
+		}
+	}
+}

--- a/ResultSharp/ResultLinqExtensions.cs
+++ b/ResultSharp/ResultLinqExtensions.cs
@@ -1,0 +1,51 @@
+﻿using System;
+
+namespace ResultSharp
+{
+	public static class ResultLinqExtensions
+	{
+		#region Result<T, E>
+
+		public static Result<TResult, TErr> SelectMany<TSource, TCollection, TResult, TErr>(
+			this Result<TSource, TErr> result,
+			Func<TSource, Result<TCollection, TErr>> collectionSelector,
+			Func<TSource, TCollection, TResult> resultSelector
+		) =>
+			result.AndThen(a => collectionSelector(a).Map(b => resultSelector(a, b)));
+
+		public static Result<TResult, TErr> SelectMany<TSource, TResult, TErr>(
+			this Result<TSource, TErr> result,
+			Func<TSource, Result<TResult, TErr>> selector
+		) => result.AndThen(selector);
+
+		public static Result<TResult, TErr> Select<TSource, TResult, TErr>(
+			this Result<TSource, TErr> result,
+			Func<TSource, TResult> selector
+		) => result.Map(selector);
+
+		#endregion
+
+
+
+		#region Result<T>
+
+		public static Result<TResult> SelectMany<TSource, TCollection, TResult>(
+			this Result<TSource> result,
+			Func<TSource, Result<TCollection>> collectionSelector,
+			Func<TSource, TCollection, TResult> resultSelector
+		) =>
+			result.AndThen(a => collectionSelector(a).Map(b => resultSelector(a, b)));
+
+		public static Result<TResult> SelectMany<TSource, TResult>(
+			this Result<TSource> result,
+			Func<TSource, Result<TResult>> selector
+		) => result.AndThen(selector);
+
+		public static Result<TResult> Select<TSource, TResult>(
+			this Result<TSource> result,
+			Func<TSource, TResult> selector
+		) => result.Map(selector);
+
+		#endregion
+	}
+}


### PR DESCRIPTION
This implements `Select` and `SelectMany` extension methods for `Result<T>` and `Result<T, E>`, which enables the use of Linq query expressions to compose Results.

A common pattern is to compose a series of dependent computations using nested calls to `.AndThen`, combining the results in the end.
However, this quickly leads to indentation getting out of hand:

```csharp
Func1().AndThen(v1 =>
    Func2(v1).AndThen(v2 =>
        Func3(v2).AndThen(v3 =>
            Func4(v3).Map(v4 => (v1, v2, v3, v4)))));
```

It is possible to flatten this manually by constructing intermediate tuples at each step, but this becomes even more verbose:

```csharp
Func1()
    .AndThen(v1 => Func2(v1).Map(v2 => (v1, v2)))
    .AndThen(x => Func3(x.v2).Map(v3 => (x.v1, x.v2, v3)))
    .AndThen(x => Func4(x.v3).Map(v4 => (x.v1, x.v2, x.v3, v4)))
```

By implementing `SelectMany` extension methods for Result types, we can compose them using query expressions instead:

```csharp
from v1 in Func1()
from v2 in Func2(v1)
from v3 in Func3(v2)
from v4 in Func4(v3)
select (v1, v2, v3, v4);
```