### PR TITLE
Make class-generic constructor functions public

### DIFF
--- a/ResultSharp/ResultT.cs
+++ b/ResultSharp/ResultT.cs
@@ -34,10 +34,10 @@ public readonly struct Result<T> :
     /// <inheritdoc cref="Result{T, E}.ErrType" />
     public Type ErrType => Inner.ErrType;
 
-    internal static Result<T> Ok(T value) =>
+    public static Result<T> Ok(T value) =>
         new(Result<T, string>.Ok(value));
 
-    internal static Result<T> Err(string error) =>
+    public static Result<T> Err(string error) =>
         new(Result<T, string>.Err(error));
 
     /// <inheritdoc cref="Result{T, E}.Match{Ret}(Func{T, Ret}, Func{E, Ret})"/>

--- a/ResultSharp/ResultTE.cs
+++ b/ResultSharp/ResultTE.cs
@@ -64,10 +64,10 @@ public readonly struct Result<T, E> :
         );
     }
 
-    internal static Result<T, E> Ok(T value) =>
+    public static Result<T, E> Ok(T value) =>
         new(value);
 
-    internal static Result<T, E> Err(E error) =>
+    public static Result<T, E> Err(E error) =>
         new(error);
 
     /// <summary>


### PR DESCRIPTION
This makes the static `Ok` and `Err` methods on `Result<T>` and `Result<T, E>` public. This change does not result in any conflicts in our codebase, which uses ResultSharp extensively, so I can't see a good reason to keep these internal.

This is particularly convenient in cases where we have a type alias for a parameterized Result type, and want to construct a result containing a value/error which does not match T/E exactly and needs to be upcasted, for example:

```csharp

// Given a type alias like this:

using MyResult = Result<BaseType, MyError>;


// And a class hierarchy like this:

class BaseType {}
class DerivedType : BaseType {}


// Since C# does not allow classes with variadic type parameters, we currently have to do something like this:

MyResult GetResult() =>
    Ok<BaseType, MyError>(new DerivedType());

MyResult GetResult() =>
    Result.Ok<BaseType, MyError>(new DerivedType());

MyResult GetResult() =>
    Ok((BaseType)new DerivedType());

MyResult GetResult()
{
    BaseType value = new DerivedType();
    return Ok(value);
}


// Now we can do this instead:

MyResult GetResult() =>
    MyResult.Ok(new DerivedType());

```